### PR TITLE
Add rate limiter using NestJS Throttler

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@nestjs/core": "^10.2.10",
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/platform-express": "^10.2.10",
+    "@nestjs/throttler": "^5.1.1",
     "@prisma/client": "^5.6.0",
     "@supabase/supabase-js": "^2.39.0",
     "argon2": "^0.31.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   '@nestjs/platform-express':
     specifier: ^10.2.10
     version: 10.2.10(@nestjs/common@10.2.10)(@nestjs/core@10.2.10)
+  '@nestjs/throttler':
+    specifier: ^5.1.1
+    version: 5.1.1(@nestjs/common@10.2.10)(@nestjs/core@10.2.10)(reflect-metadata@0.1.13)
   '@prisma/client':
     specifier: ^5.6.0
     version: 5.6.0(prisma@5.6.0)
@@ -1104,6 +1107,19 @@ packages:
       '@nestjs/platform-express': 10.2.10(@nestjs/common@10.2.10)(@nestjs/core@10.2.10)
       tslib: 2.6.2
     dev: true
+
+  /@nestjs/throttler@5.1.1(@nestjs/common@10.2.10)(@nestjs/core@10.2.10)(reflect-metadata@0.1.13):
+    resolution: {integrity: sha512-0fJAGroqpQLnQlERslx2fG264YCXU35nMfiFhykY6/chgc56/W0QPM6BEEf9Q/Uca9lXh5IyjE0fqFToksbP/A==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+      '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+      reflect-metadata: ^0.1.13 || ^0.2.0
+    dependencies:
+      '@nestjs/common': 10.2.10(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/core': 10.2.10(@nestjs/common@10.2.10)(@nestjs/platform-express@10.2.10)(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      md5: 2.3.0
+      reflect-metadata: 0.1.13
+    dev: false
 
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2220,6 +2236,10 @@ packages:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
     dev: true
 
+  /charenc@0.0.2:
+    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+    dev: false
+
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
@@ -2475,6 +2495,10 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
     dev: true
+
+  /crypt@0.0.2:
+    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
+    dev: false
 
   /custom-error-instance@2.1.1:
     resolution: {integrity: sha512-p6JFxJc3M4OTD2li2qaHkDCw9SfMw82Ldr6OC9Je1aXiGfhx2W8p3GaoeaGrPJTUN9NirTM/KTxHWMUdR1rsUg==}
@@ -3531,6 +3555,10 @@ packages:
       binary-extensions: 2.2.0
     dev: true
 
+  /is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+    dev: false
+
   /is-core-module@2.13.1:
     resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
     dependencies:
@@ -4409,6 +4437,14 @@ packages:
     dependencies:
       tmpl: 1.0.5
     dev: true
+
+  /md5@2.3.0:
+    resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
+    dependencies:
+      charenc: 0.0.2
+      crypt: 0.0.2
+      is-buffer: 1.1.6
+    dev: false
 
   /media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,21 +21,21 @@ import { ThrottlerModule } from "@nestjs/throttler";
         CacheModule.register({ ttl: 5 * 1000 }),
         ThrottlerModule.forRoot([
             {
-              name: 'short',
-              ttl: 1000,
-              limit: 3,
+                name: "short",
+                ttl: 1000,
+                limit: 3,
             },
             {
-              name: 'medium',
-              ttl: 10000,
-              limit: 20
+                name: "medium",
+                ttl: 10000,
+                limit: 20,
             },
             {
-              name: 'long',
-              ttl: 60000,
-              limit: 100
-            }
-          ]),
+                name: "long",
+                ttl: 60000,
+                limit: 100,
+            },
+        ]),
     ],
     providers: [
         {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { HealthModule } from "./api/health/health.module";
 import { ProjectModule } from "./api/project/project.module";
 import { PublicModule } from "./api/public/public.module";
 import { HttpLoggerMiddleware } from "./shared/middlewares/logger";
+import { ThrottlerModule } from "@nestjs/throttler";
 
 @Module({
     imports: [
@@ -18,6 +19,23 @@ import { HttpLoggerMiddleware } from "./shared/middlewares/logger";
         DatabaseModule,
         PublicModule,
         CacheModule.register({ ttl: 5 * 1000 }),
+        ThrottlerModule.forRoot([
+            {
+              name: 'short',
+              ttl: 1000,
+              limit: 3,
+            },
+            {
+              name: 'medium',
+              ttl: 10000,
+              limit: 20
+            },
+            {
+              name: 'long',
+              ttl: 60000,
+              limit: 100
+            }
+          ]),
     ],
     providers: [
         {


### PR DESCRIPTION

# Description
This pull request adds a rate limiter to the application using the NestJS Throttler module. The rate limiter is configured with three different throttling options: 'short', 'medium', and 'long', each with their own time-to-live (TTL) and request limit. This will help prevent abuse and protect the application from excessive requests.

List any dependencies that are required for this change.
- **@nestjs/throttler**

## Type of change

- [x] New feature (non-breaking change which adds functionality)
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [Idocumentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
